### PR TITLE
Fix JVM method signatures containing inner class param types.

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -5,6 +5,9 @@ plugins { kotlin("jvm") }
 dependencies {
     compile(kotlin("stdlib"))
     compile("me.eugeniomarletti.kotlin.metadata:kotlin-compiler-lite:1.0.3-k-1.2.40")
+    
+    testCompile("junit:junit:4.12")
+    testCompile("com.google.testing.compile:compile-testing:0.15")
 }
 
 tasks.withType<KotlinCompile> {

--- a/lib/src/main/kotlin/me/eugeniomarletti/kotlin/metadata/jvm/JvmDescriptorUtils.kt
+++ b/lib/src/main/kotlin/me/eugeniomarletti/kotlin/metadata/jvm/JvmDescriptorUtils.kt
@@ -2,7 +2,9 @@ package me.eugeniomarletti.kotlin.metadata.jvm
 
 import me.eugeniomarletti.kotlin.processing.KotlinProcessingEnvironment
 import javax.lang.model.element.Element
+import javax.lang.model.element.NestingKind
 import javax.lang.model.element.QualifiedNameable
+import javax.lang.model.element.TypeElement
 import javax.lang.model.type.ArrayType
 import javax.lang.model.type.DeclaredType
 import javax.lang.model.type.ErrorType
@@ -68,6 +70,17 @@ interface JvmDescriptorUtils : KotlinProcessingEnvironment {
  */
 val Element.internalName: String
     get() = when (this) {
+        is TypeElement ->
+            when (nestingKind) {
+                NestingKind.TOP_LEVEL ->
+                    qualifiedName.toString().replace('.', '/')
+                NestingKind.MEMBER ->
+                    enclosingElement.internalName + "$" + simpleName
+                NestingKind.LOCAL, NestingKind.ANONYMOUS ->
+                    error("Unsupported nesting $nestingKind")
+                else ->
+                    error("Unsupported, nestingKind == null")
+            }
         is QualifiedNameable -> qualifiedName.toString().replace('.', '/')
         else -> simpleName.toString()
     }

--- a/lib/src/test/kotlin/me/eugeniomarletti/kotlin/metadata/jvm/JvmDescriptorUtilsTest.kt
+++ b/lib/src/test/kotlin/me/eugeniomarletti/kotlin/metadata/jvm/JvmDescriptorUtilsTest.kt
@@ -1,0 +1,227 @@
+package me.eugeniomarletti.kotlin.metadata.jvm
+
+import com.google.auto.common.MoreElements
+import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
+import com.google.testing.compile.CompileTester
+import com.google.testing.compile.JavaFileObjects
+import com.google.testing.compile.JavaSourcesSubjectFactory
+import me.eugeniomarletti.kotlin.metadata.testing.TestProcessor
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import javax.tools.JavaFileObject
+
+@RunWith(JUnit4::class)
+class JvmDescriptorUtilsTest {
+
+    private val describeAnnotation = """
+        package me.eugeniomarletti.kotlin.test;
+
+        import java.lang.annotation.ElementType;
+        import java.lang.annotation.Target;
+
+        @Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
+        public @interface Describe { }
+        """.toJFO("me.eugeniomarletti.kotlin.test.Describe")
+
+    @Test
+    fun method_descriptor_simple() {
+        singleRun("""
+            package me.eugeniomarletti.kotlin.test;
+            
+            public class DummyClass {
+                @Describe
+                public void emptyMethod() {
+                }
+            }
+            """.toJFO("me.eugeniomarletti.kotlin.test.DummyClass")
+        ) { descriptors ->
+            assertThat(descriptors.first())
+                    .isEqualTo("emptyMethod()V")
+        }.compilesWithoutError()
+    }
+
+    @Test
+    fun method_descriptor_primitiveParams() {
+        singleRun(
+                """
+            package me.eugeniomarletti.kotlin.test;
+            
+            class DummyClass {
+                @Describe
+                void method1(boolean yesOrNo, int number) { }
+                
+                @Describe
+                byte method2(char letter) { return 0; }
+                
+                @Describe
+                void method3(double realNumber1, float realNumber2) { }
+                
+                @Describe
+                void method4(long bigNumber, short littlerNumber) { }
+            }
+            """.toJFO("me.eugeniomarletti.kotlin.test.DummyClass")
+        ) { descriptors ->
+            assertThat(descriptors)
+                    .isEqualTo(setOf("method1(ZI)V", "method2(C)B", "method3(DF)V", "method4(JS)V"))
+        }.compilesWithoutError()
+    }
+
+    @Test
+    fun method_descriptor_classParam_javaTypes() {
+        singleRun(
+                """
+            package me.eugeniomarletti.kotlin.test;
+            
+            import java.util.ArrayList;
+            import java.util.List;
+            
+            class DummyClass {
+                @Describe
+                void method1(Object something) { }
+                
+                @Describe
+                Object method2() { return null; }
+                
+                @Describe
+                List<String> method3(ArrayList<Integer> list) { return null; }
+            }
+            """.toJFO("me.eugeniomarletti.kotlin.test.DummyClass")
+        ) { descriptors ->
+            assertThat(descriptors).isEqualTo(
+                    setOf(
+                            "method1(Ljava/lang/Object;)V",
+                            "method2()Ljava/lang/Object;",
+                            "method3(Ljava/util/ArrayList;)Ljava/util/List;"
+                    )
+            )
+        }.compilesWithoutError()
+    }
+
+    @Test
+    fun method_descriptor_classParam_testClass() {
+        val extraJfo = """
+            package me.eugeniomarletti.kotlin.test;
+            class DataClass { }
+            """.toJFO("me.eugeniomarletti.kotlin.test.DataClass")
+        singleRun("""
+            package me.eugeniomarletti.kotlin.test;
+            
+            class DummyClass {
+                @Describe
+                void method1(DataClass data) { }
+                
+                @Describe
+                DataClass method2() { return null; }
+            }
+            """.toJFO("me.eugeniomarletti.kotlin.test.DummyClass"), extraJfo
+        ) { descriptors ->
+            assertThat(descriptors).isEqualTo(
+                    setOf(
+                            "method1(Lme/eugeniomarletti/kotlin/test/DataClass;)V",
+                            "method2()Lme/eugeniomarletti/kotlin/test/DataClass;"
+                    )
+            )
+        }.compilesWithoutError()
+    }
+
+    @Test
+    fun method_descriptor_classParam_innerTestClass() {
+        val extraJfo = """
+            package me.eugeniomarletti.kotlin.test;
+            
+            class DataClass {
+            
+                class MemberInnerData { }
+                
+                static class StaticInnerData { }
+                
+                enum EnumData {
+                    VALUE1, VALUE2
+                }
+            }
+            """.toJFO("me.eugeniomarletti.kotlin.test.DataClass")
+        singleRun("""
+            package me.eugeniomarletti.kotlin.test;
+            
+            class DummyClass {
+                @Describe
+                void method1(DataClass.MemberInnerData data) { }
+                
+                @Describe
+                void method2(DataClass.StaticInnerData data) { }
+                
+                @Describe
+                void method3(DataClass.EnumData enumData) { }
+                
+                @Describe
+                DataClass.StaticInnerData method4() { return null; }
+            }
+            """.toJFO("me.eugeniomarletti.kotlin.test.DummyClass"), extraJfo
+        ) { descriptors ->
+            assertThat(descriptors).isEqualTo(
+                    setOf(
+                            "method1(Lme/eugeniomarletti/kotlin/test/DataClass\$MemberInnerData;)V",
+                            "method2(Lme/eugeniomarletti/kotlin/test/DataClass\$StaticInnerData;)V",
+                            "method3(Lme/eugeniomarletti/kotlin/test/DataClass\$EnumData;)V",
+                            "method4()Lme/eugeniomarletti/kotlin/test/DataClass\$StaticInnerData;"
+                    )
+            )
+        }.compilesWithoutError()
+    }
+
+    @Test
+    fun method_descriptor_arrayParams() {
+        val extraJfo = """
+            package me.eugeniomarletti.kotlin.test;
+            class DataClass { }
+            """.toJFO("me.eugeniomarletti.kotlin.test.DataClass")
+        singleRun("""
+            package me.eugeniomarletti.kotlin.test;
+            
+            class DummyClass {
+                @Describe
+                void method1(DataClass[] data) { }
+                
+                @Describe
+                DataClass[] method2() { return null; }
+                
+                @Describe
+                void method3(int[] array) { }
+                
+                @Describe
+                void method4(int... array) { }
+            }
+            """.toJFO("me.eugeniomarletti.kotlin.test.DummyClass"), extraJfo
+        ) { descriptors ->
+            assertThat(descriptors).isEqualTo(
+                    setOf(
+                            "method1([Lme/eugeniomarletti/kotlin/test/DataClass;)V",
+                            "method2()[Lme/eugeniomarletti/kotlin/test/DataClass;",
+                            "method3([I)V",
+                            "method4([I)V"
+                    )
+            )
+        }.compilesWithoutError()
+    }
+
+    private fun String.toJFO(qName: String): JavaFileObject = JavaFileObjects.forSourceLines(qName, this)
+
+    // Run TestProcessor to gather jvm signature of method elements annotated with @Describe
+    private fun singleRun(
+            vararg jfo: JavaFileObject,
+            handler: (Set<String>) -> Unit
+    ): CompileTester = Truth.assertAbout(JavaSourcesSubjectFactory.javaSources())
+            .that(listOf(describeAnnotation) + jfo)
+            .processedWith(TestProcessor.builder()
+                    .nextRunHandler { invocation ->
+                        invocation.roundEnv.getElementsAnnotatedWith(invocation.annotations.first()).map { element ->
+                            with(invocation.metadataUtils) { MoreElements.asExecutable(element).jvmMethodSignature }
+                        }.toSet().let(handler)
+                        true
+                    }
+                    .forAnnotations("me.eugeniomarletti.kotlin.test.Describe")
+                    .build())
+
+}

--- a/lib/src/test/kotlin/me/eugeniomarletti/kotlin/metadata/testing/TestInvocation.kt
+++ b/lib/src/test/kotlin/me/eugeniomarletti/kotlin/metadata/testing/TestInvocation.kt
@@ -1,0 +1,13 @@
+package me.eugeniomarletti.kotlin.metadata.testing
+
+import me.eugeniomarletti.kotlin.metadata.KotlinMetadataUtils
+import javax.annotation.processing.ProcessingEnvironment
+import javax.annotation.processing.RoundEnvironment
+import javax.lang.model.element.TypeElement
+
+data class TestInvocation(
+        val processingEnv: ProcessingEnvironment,
+        val metadataUtils: KotlinMetadataUtils,
+        val annotations: Set<TypeElement>,
+        val roundEnv: RoundEnvironment
+)

--- a/lib/src/test/kotlin/me/eugeniomarletti/kotlin/metadata/testing/TestProcessor.kt
+++ b/lib/src/test/kotlin/me/eugeniomarletti/kotlin/metadata/testing/TestProcessor.kt
@@ -1,0 +1,61 @@
+package me.eugeniomarletti.kotlin.metadata.testing
+
+import me.eugeniomarletti.kotlin.metadata.KotlinMetadataUtils
+import javax.annotation.processing.AbstractProcessor
+import javax.annotation.processing.ProcessingEnvironment
+import javax.annotation.processing.RoundEnvironment
+import javax.lang.model.element.TypeElement
+import kotlin.reflect.KClass
+
+class TestProcessor private constructor(
+        private val handlers: List<(TestInvocation) -> Boolean>,
+        private val annotations: MutableSet<String>
+) : AbstractProcessor(), KotlinMetadataUtils {
+    private var count = 0
+
+    override val processingEnv: ProcessingEnvironment
+        get() = super.processingEnv
+
+    override fun process(annotations: Set<TypeElement>, roundEnv: RoundEnvironment): Boolean {
+        return handlers.getOrNull(count++)?.invoke(
+                TestInvocation(super.processingEnv, this, annotations, roundEnv)) ?: true
+    }
+
+    override fun getSupportedAnnotationTypes(): MutableSet<String> {
+        return annotations
+    }
+
+    class Builder {
+        private var handlers = arrayListOf<(TestInvocation) -> Boolean>()
+        private var annotations = mutableSetOf<String>()
+
+        fun nextRunHandler(f: (TestInvocation) -> Boolean): Builder {
+            handlers.add(f)
+            return this
+        }
+
+        fun forAnnotations(vararg klasses: KClass<*>): Builder {
+            annotations.addAll(klasses.map { it.java.canonicalName })
+            return this
+        }
+
+        fun forAnnotations(vararg names: String): Builder {
+            annotations.addAll(names)
+            return this
+        }
+
+        fun build(): TestProcessor {
+            if (annotations.isEmpty()) {
+                throw IllegalStateException("must provide at least 1 annotation")
+            }
+            if (handlers.isEmpty()) {
+                throw IllegalStateException("must provide at least 1 handler")
+            }
+            return TestProcessor(handlers, annotations)
+        }
+    }
+
+    companion object {
+        fun builder(): Builder = Builder()
+    }
+}


### PR DESCRIPTION
jvms-4.3.4 specifies that a ClassSignature can contain zero or more
ClassTypeSignatureSuffix that are useful for uniquely identify inner
classes. For example, the ClassSignature of java.util.Map.Entry<K,V> is
Ljava.util.Map$Entry;

Note that even though local and anonymous classes do have signatures,
this change doesn't consider them because they can't be part of an
annotation processor discoverable method.

Also added compile-testing and small testing classes that help run a
dummy annotation processor to obtain a ProcessingEnvironment to exercise
library code.

This should help with issue #7.